### PR TITLE
Upgrade Cypress

### DIFF
--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,4 +1,4 @@
-import { mount } from 'cypress/react18'
+import { mount } from 'cypress/react'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "^19.0.2",
     "@types/react-is": "^19.0.0",
     "@vitejs/plugin-react-swc": "^3.7.2",
-    "cypress": "^13.17.0",
+    "cypress": "^14.1.0",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^3.7.2
         version: 3.7.2(vite@5.4.11(@types/node@22.10.2))
       cypress:
-        specifier: ^13.17.0
-        version: 13.17.0
+        specifier: ^14.1.0
+        version: 14.1.0
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -970,9 +970,9 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  cypress@13.17.0:
-    resolution: {integrity: sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==}
-    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
+  cypress@14.1.0:
+    resolution: {integrity: sha512-pPPj8Uu9NwjaaiXAEcjYZZmgsq6v9Zs1Nw6a+zRF+ANgYSNhH4S32SjFRsvMcuOHR/8dp4GBJhBPqIPSs+TxaA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   dashdash@1.14.1:
@@ -3358,7 +3358,7 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cypress@13.17.0:
+  cypress@14.1.0:
     dependencies:
       '@cypress/request': 3.0.7
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)


### PR DESCRIPTION
Fixes issue with Cypress where it didn't support React 19. It now uses the latest Cypress and has an updated `mount` import path:
https://docs.cypress.io/app/references/migration-guide#React-18-CT-no-longer-supported